### PR TITLE
Nlp 24

### DIFF
--- a/chatnet/general_classifier_model.py
+++ b/chatnet/general_classifier_model.py
@@ -1,0 +1,153 @@
+# -*- coding: utf-8 -*-
+"""
+    general_classifier_model.py
+    ~~~~~~~~
+
+    General pipeline for classifiers and regressors
+
+    USAGE
+    ~~~~~
+
+    Single Classifier:
+        pipe = ClassifierPipeline(**super_kwargs)
+        pipe.setup(df)
+        pipe.run(classifier, classifier_arguments)
+
+    Regression:
+        pipe = ClassifierPipeline(**super_kwargs)
+        pipe.setup(df)
+        pipe.run(regressor, regressor_arguments)
+
+    Multiple Classifiers w/ Voting:
+        pipe = ClassifierPipeline(**super_kwargs)
+        pipe.setup(df)
+        pipe.run([(cl_0, {cl_0_args}), (cl_1, ), ...], VotingClassifier_args)
+
+"""
+from chatnet.pipes import Pipeline
+
+from . import logger
+from collections import Counter
+import math
+from scipy import sparse
+import numpy as np
+from sklearn.svm import SVC
+from sklearn.decomposition import TruncatedSVD
+from sklearn.ensemble import VotingClassifier
+
+
+def sequence_to_csr(row):
+    bow_counts = Counter(row)
+    for word_ix, ct in bow_counts.iteritems():
+        yield (word_ix, ct)
+
+
+def create_csr_matrix(x_train, n_symbols, skip_top=3):
+    """
+    Given training data in form of sequences of word indices
+    create sparse matrix of vocab-wide count vectors
+    """
+    rows = []
+    cols = []
+    vals = []
+
+    for data_ix, row in enumerate(x_train):
+        for word_ix, ct in sequence_to_csr(row):
+            if word_ix < skip_top:
+                continue
+            rows.append(data_ix)
+            cols.append(word_ix)
+            vals.append(ct)
+
+    return sparse.csr_matrix(
+        (np.array(vals), (np.array(rows), np.array(cols))),
+        shape=(len(x_train), n_symbols)
+    )
+
+
+def create_vsm_matrix(x_train, embeddings):
+    rows = []
+    for data_ix, row in enumerate(x_train):
+        row_data = []
+        for word_ix in row:
+            row_data.append(embeddings[word_ix])
+        rows.append(np.hstack(row_data))
+
+    return np.array(rows)
+
+
+def train_pca_classifier(learning_data, pca_dims, classifier=SVC, **cl_kwargs):
+    (X_train, y_train, train_ids), (X_test, y_test, test_ids) = learning_data
+
+    pca = TruncatedSVD(n_components=pca_dims)
+    n_symbols = max(
+        np.max(X_train) + 1, np.max(X_test) + 1
+    )
+    logger.info("Forming CSR Matrices")
+    x_train, x_test = create_csr_matrix(X_train, n_symbols), create_csr_matrix(X_test, n_symbols)
+    logger.info("Starting PCA")
+    # pseudo-supervised PCA: fit on positive class only
+    pca = pca.fit(x_train[y_train > 0])
+
+    x_train_pca = pca.transform(x_train)
+    x_test_pca = pca.transform(x_test)
+
+    logger.info("Starting Classifier")
+    if isinstance(classifier, list):
+        cl_list = []
+        for i in range(len(classifier)):
+            cl_str = "cl" + str(i)
+            cl_i_args = {} if not classifier[i][1:] else classifier[i][1:][0]
+            cl_list.append((cl_str, classifier[i][0](**cl_i_args)))
+        cl = VotingClassifier(cl_list, **cl_kwargs)
+    else:
+        cl = classifier(**cl_kwargs)
+    cl.fit(x_train_pca, y_train)
+    logger.info("Scoring Classifier")
+    score = cl.score(x_test_pca, y_test)
+    logger.info(score)
+    cl.test_score = score
+    pca.n_symbols = n_symbols
+    return cl, pca, x_train_pca, x_test_pca
+
+
+def get_pca_mats(learning_data, pca):
+    (X_train, y_train, train_ids), (X_test, y_test, test_ids) = learning_data
+    n_symbols = np.max(X_train) + 1
+    x_train, x_test = create_csr_matrix(X_train, n_symbols), create_csr_matrix(X_test, n_symbols)
+    if not pca:
+        return x_train, x_test
+    return pca.transform(x_train), pca.transform(x_test)
+
+
+class ClassifierPipeline(Pipeline):
+    captured_kwargs = {'pca_dims', 'df'}
+    persisted_attrs = {'cl', 'pca', 'word_index'}
+    def __init__(self, *args, **kwargs):
+        super_kwargs = {k: v for k, v in kwargs.iteritems() if k not in self.captured_kwargs}
+        super(ClassifierPipeline, self).__init__(**super_kwargs)
+        self.pca_dims = kwargs.get('pca_dims', 500)
+        if 'df' in kwargs:
+            self.setup(kwargs['df'])
+
+    def run(self, classifier, **cl_kwargs):
+        self.cl, self.pca, self.x_train_pca, self.x_test_pca = train_pca_classifier(self.learning_data, self.pca_dims, classifier, **cl_kwargs)
+        return self.cl.test_score
+
+    def predict(self, new_df):
+        self._set_token_data(new_df)
+        self._set_learning_data(test_split=0., max_dummy_ratio=1)
+        (X, y, ids), _ = self.learning_data
+        if len(X) == 0:
+            return None
+        x_pca = self.pca.transform(create_csr_matrix(X, self.pca.n_symbols))
+        return (self.cl.predict_proba(x_pca), ids)
+
+    def predict_and_score(self, new_df):
+        self._set_token_data(new_df)
+        self._set_learning_data(test_split=0., max_dummy_ratio=1)
+        (X, y, ids), _ = self.learning_data
+        if len(X) == 0:
+            return None
+        x_pca = self.pca.transform(create_csr_matrix(X, self.pca.n_symbols))
+        return self.cl.score(x_pca, y)

--- a/chatnet/general_classifier_model.py
+++ b/chatnet/general_classifier_model.py
@@ -130,7 +130,7 @@ class ClassifierPipeline(Pipeline):
         if 'df' in kwargs:
             self.setup(kwargs['df'])
 
-    def run(self, classifier, **cl_kwargs):
+    def run(self, classifier=SVC, **cl_kwargs):
         self.cl, self.pca, self.x_train_pca, self.x_test_pca = train_pca_classifier(self.learning_data, self.pca_dims, classifier, **cl_kwargs)
         return self.cl.test_score
 

--- a/chatnet/general_classifier_model.py
+++ b/chatnet/general_classifier_model.py
@@ -143,11 +143,11 @@ class ClassifierPipeline(Pipeline):
         x_pca = self.pca.transform(create_csr_matrix(X, self.pca.n_symbols))
         return (self.cl.predict_proba(x_pca), ids)
 
-    def predict_and_score(self, new_df):
+    def test_and_score(self, new_df):
         self._set_token_data(new_df)
         self._set_learning_data(test_split=0., max_dummy_ratio=1)
         (X, y, ids), _ = self.learning_data
         if len(X) == 0:
             return None
         x_pca = self.pca.transform(create_csr_matrix(X, self.pca.n_symbols))
-        return (self.cl.predict_proba(x_pca), ids, self.ca.score(x_pca, y))
+        return self.cl.score(x_pca, y)

--- a/chatnet/general_classifier_model.py
+++ b/chatnet/general_classifier_model.py
@@ -150,4 +150,4 @@ class ClassifierPipeline(Pipeline):
         if len(X) == 0:
             return None
         x_pca = self.pca.transform(create_csr_matrix(X, self.pca.n_symbols))
-        return self.cl.score(x_pca, y)
+        return (self.cl.predict_proba(x_pca), ids, self.ca.score(x_pca, y))

--- a/chatnet/pipes.py
+++ b/chatnet/pipes.py
@@ -14,7 +14,7 @@ class Pipeline(object):
     def __init__(self, vocab_size=15000, value_filter=None,
                  data_col=None, id_col=None, label_col=None,
                  strict_binary=False, prepend_sender=True, binary_options={u'product', u'service'},
-                 positive_class='product', df=None, message_key=None, **kwargs):
+                 positive_class='product', df=None, message_key=None, features=[], **kwargs):
 
         # message processing
         self.value_filter = value_filter or (lambda v: True)
@@ -23,6 +23,8 @@ class Pipeline(object):
         self.label_col = label_col or 'labels'
         self.prepend_sender = prepend_sender
         self.message_key = message_key or 'msgs'
+
+        self.features = features # column list of numeric features for training
 
         # label processing
         self.label_filter = lambda v: True if not strict_binary else v in binary_options
@@ -61,9 +63,9 @@ class Pipeline(object):
         self.tp = prep.TextPrepper()
 
         self.data = data = pd.DataFrame(label_filtered_df[
-            [self.data_col, self.id_col, self.label_col]
+            [self.data_col, self.id_col, self.label_col] + self.features
             ])
-        
+
         logger.info("Counting words...")
 
         self.word_counts = prep.get_word_counts(data[self.data_col], self.tp)
@@ -83,6 +85,9 @@ class Pipeline(object):
 
         self.learning_data = (X_train, y_train, train_ids), (X_test, y_test, test_ids) = \
             self.tp.to_matrices(self.data, self.word_index, **to_matrices_kwargs)
+        if self.features: 
+            # attach numeric features to examples:
+            pass
 
     def setup(self, df):
         self._set_token_data(df)

--- a/chatnet/prep.py
+++ b/chatnet/prep.py
@@ -29,15 +29,17 @@ class TextPrepper(object):
             return '$model'
         else:
             return '$digit'
-    
+
     def to_matrices(self, df, word_index, id_col='Chat Session ID', label_col='Chat Type',
                      data_col='msgs', positive_class='product', seed=133, test_split=.2, **kwargs):
 
         df = df[~df[id_col].isnull()]
         ids = df[id_col]
-        if positive_class is None: # regression problems have no sense of 'positive class'
+        if positive_class is "scores": # regression
             labels = df[label_col]
-        else:
+        elif positive_class is "satisfaction": # binary scores (satisfied/unsatisfied) | current cutoff is [3-5] = satisfied
+            labels = df[label_col].map(lambda s: 1 if s >= 3 else 0)
+        else: # positive_class for binary moderator labels
             labels = df[label_col].map(lambda v: 1 if v == positive_class else 0)
         labels = zip(ids, labels)
         X = df[data_col].tolist()
@@ -91,7 +93,7 @@ class TextPrepper(object):
                     sum(c == self.oov_char for c in padded) > ((chunk_size - pad_size) / max_dummy_ratio)
                     or
                     all([c in self.special_chars for c in chunk])
-                    ):                    
+                    ):
                     skipped += 1
                     continue
                 else:
@@ -126,4 +128,3 @@ def get_word_index(word_counts, nb_words=15000, skip_top=None, nonembeddable=Non
             vocab.append(w)
 
     return {v: ix for ix, v in enumerate(vocab)}
-

--- a/chatnet/prep.py
+++ b/chatnet/prep.py
@@ -35,7 +35,10 @@ class TextPrepper(object):
 
         df = df[~df[id_col].isnull()]
         ids = df[id_col]
-        labels = df[label_col].map(lambda v: 1 if v == positive_class else 0)
+        if positive_class is None: # regression problems have no sense of 'positive class'
+            labels = df[label_col]
+        else:
+            labels = df[label_col].map(lambda v: 1 if v == positive_class else 0)
         labels = zip(ids, labels)
         X = df[data_col].tolist()
 

--- a/classification_test_driver.ipynb
+++ b/classification_test_driver.ipynb
@@ -1,0 +1,220 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "import sklearn\n",
+    "\n",
+    "from chatnet.general_classifier_model import ClassifierPipeline\n",
+    "\n",
+    "import warnings\n",
+    "warnings.filterwarnings('ignore')\n",
+    "\n",
+    "from sklearn.neighbors import KNeighborsClassifier, KNeighborsRegressor\n",
+    "from sklearn.svm import SVC, SVR\n",
+    "from sklearn.tree import DecisionTreeClassifier, DecisionTreeRegressor\n",
+    "from sklearn.ensemble import RandomForestClassifier, AdaBoostClassifier, RandomForestRegressor, AdaBoostRegressor, BaggingRegressor\n",
+    "from sklearn.naive_bayes import GaussianNB\n",
+    "from sklearn.discriminant_analysis import LinearDiscriminantAnalysis\n",
+    "from sklearn.discriminant_analysis import QuadraticDiscriminantAnalysis\n",
+    "from sklearn.linear_model import LinearRegression, Ridge, Lasso, LassoLars, BayesianRidge, LogisticRegression"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "# Sets up the sample data frame\n",
+    "def str_to_list(s):\n",
+    "    return s[1:-1].split(\", u\")\n",
+    "df = pd.read_csv(\"chatnet/5-25msg_score.tsv\", sep=\"\\t\")\n",
+    "df[\"msgs\"] = df[\"msgs\"].apply(str_to_list)\n",
+    "df_sample = df.sample(5000)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "default SVC: 0.86778316439\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Defaults to SVC\n",
+    "cl_pipe = ClassifierPipeline(positive_class=\"satisfaction\")\n",
+    "cl_pipe.setup(df_sample)\n",
+    "cl_pipe.run()\n",
+    "print \"default SVC:\", cl_pipe.cl.test_score"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "AdaBoost: 0.842221242838\n",
+      "Random Forest: 0.865138827677\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Running with arguments\n",
+    "\n",
+    "# Single list of tuple of classifier, arguments\n",
+    "cl_pipe = ClassifierPipeline(positive_class=\"satisfaction\")\n",
+    "cl_pipe.setup(df_sample)\n",
+    "cl_pipe.run([(AdaBoostClassifier, {\"n_estimators\": 100})])\n",
+    "print \"AdaBoost:\", cl_pipe.cl.test_score\n",
+    "\n",
+    "# Classifier, arguments\n",
+    "cl_pipe.run(RandomForestClassifier, class_weight = {0: 2, 1: 1})\n",
+    "print \"Random Forest:\", cl_pipe.cl.test_score"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "# Lists of classifiers and regressors to test\n",
+    "classifiers = [KNeighborsClassifier, [(SVC, {\"probability\": True})], DecisionTreeClassifier, RandomForestClassifier, AdaBoostClassifier, GaussianNB, LinearDiscriminantAnalysis, QuadraticDiscriminantAnalysis]\n",
+    "regressors = [KNeighborsRegressor, SVR, DecisionTreeRegressor, RandomForestRegressor, AdaBoostRegressor, BaggingRegressor, LinearRegression, Ridge, BayesianRidge, LogisticRegression]\n",
+    "classifier_sets = [[(SVC, {\"probability\": True, \"cache_size\": 3000}), (GaussianNB, )], [(SVC, {\"probability\": True, \"cache_size\": 3000}), (GaussianNB,), (DecisionTreeClassifier, {\"class_weight\": {0: 2, 1: 1}})]]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "TESTING SINGLE CLASSIFIERS\n",
+      "\n",
+      "single classifier: <class 'sklearn.neighbors.classification.KNeighborsClassifier'> 0.832966064346\n",
+      "single classifier: [(<class 'sklearn.svm.classes.SVC'>, {'probability': True})] 0.86778316439\n",
+      "single classifier: <class 'sklearn.tree.tree.DecisionTreeClassifier'> 0.783605112384\n",
+      "single classifier: <class 'sklearn.ensemble.forest.RandomForestClassifier'> 0.861172322609\n",
+      "single classifier: <class 'sklearn.ensemble.weight_boosting.AdaBoostClassifier'> 0.854561480829\n",
+      "single classifier: <class 'sklearn.naive_bayes.GaussianNB'> 0.494490965183\n",
+      "single classifier: <class 'sklearn.discriminant_analysis.LinearDiscriminantAnalysis'> 0.865579550463\n",
+      "single classifier: <class 'sklearn.discriminant_analysis.QuadraticDiscriminantAnalysis'> 0.783605112384\n",
+      "\n",
+      "TESTING ENSEMBLE VOTING CLASSIFIERS\n",
+      "\n",
+      "SOFT VOTING\n",
+      "soft set: [(<class 'sklearn.svm.classes.SVC'>, {'cache_size': 3000, 'probability': True}), (<class 'sklearn.naive_bayes.GaussianNB'>,)] 0.5813133539\n",
+      "\n",
+      "HARD VOTING\n",
+      "hard set: [(<class 'sklearn.svm.classes.SVC'>, {'cache_size': 3000, 'probability': True}), (<class 'sklearn.naive_bayes.GaussianNB'>,)] 0.494490965183\n",
+      "\n",
+      "SOFT VOTING\n",
+      "soft set: [(<class 'sklearn.svm.classes.SVC'>, {'cache_size': 3000, 'probability': True}), (<class 'sklearn.naive_bayes.GaussianNB'>,), (<class 'sklearn.tree.tree.DecisionTreeClassifier'>, {'class_weight': {0: 2, 1: 1}})] 0.824592331424\n",
+      "\n",
+      "HARD VOTING\n",
+      "hard set: [(<class 'sklearn.svm.classes.SVC'>, {'cache_size': 3000, 'probability': True}), (<class 'sklearn.naive_bayes.GaussianNB'>,), (<class 'sklearn.tree.tree.DecisionTreeClassifier'>, {'class_weight': {0: 2, 1: 1}})] 0.829440282063\n",
+      "\n",
+      "TESTING REGRESSORS\n",
+      "\n",
+      "regression: <class 'sklearn.neighbors.regression.KNeighborsRegressor'> -0.132759607411\n",
+      "regression: <class 'sklearn.svm.classes.SVR'> -0.099205060002\n",
+      "regression: <class 'sklearn.tree.tree.DecisionTreeRegressor'> -0.827721346704\n",
+      "regression: <class 'sklearn.ensemble.forest.RandomForestRegressor'> -0.0201493030421\n",
+      "regression: <class 'sklearn.ensemble.weight_boosting.AdaBoostRegressor'> -0.0145155720725\n",
+      "regression: <class 'sklearn.ensemble.bagging.BaggingRegressor'> -0.0420124053246\n",
+      "regression: <class 'sklearn.linear_model.base.LinearRegression'> 0.0257177774953\n",
+      "regression: <class 'sklearn.linear_model.ridge.Ridge'> 0.0260764877562\n",
+      "regression: <class 'sklearn.linear_model.bayes.BayesianRidge'> 0.0635677759968\n",
+      "regression: <class 'sklearn.linear_model.logistic.LogisticRegression'> 0.631555751432\n"
+     ]
+    }
+   ],
+   "source": [
+    "print \"\\nTESTING SINGLE CLASSIFIERS\\n\"\n",
+    "for classifier in classifiers:\n",
+    "    cl_pipe = ClassifierPipeline(positive_class=\"satisfaction\")\n",
+    "    cl_pipe.setup(df_sample)\n",
+    "    cl_pipe.run(classifier)\n",
+    "    print \"single classifier:\", classifier, cl_pipe.cl.test_score\n",
+    "\n",
+    "print \"\\nTESTING ENSEMBLE VOTING CLASSIFIERS\"\n",
+    "for cl_set in classifier_sets:\n",
+    "\n",
+    "    # Ensemble voting with soft voting\n",
+    "    print \"\\nSOFT VOTING\"\n",
+    "    cl_set_soft_pipe = ClassifierPipeline(positive_class=\"satisfaction\")\n",
+    "    cl_set_soft_pipe.setup(df_sample)\n",
+    "    cl_set_soft_pipe.run(cl_set, voting=\"soft\")\n",
+    "    print \"soft set:\", cl_set, cl_set_soft_pipe.cl.test_score\n",
+    "\n",
+    "    # Ensemble voting with hard voting\n",
+    "    print \"\\nHARD VOTING\"\n",
+    "    cl_set_hard_pipe = ClassifierPipeline(positive_class=\"satisfaction\")\n",
+    "    cl_set_hard_pipe.setup(df_sample)\n",
+    "    cl_set_hard_pipe.run(cl_set)\n",
+    "    print \"hard set:\", cl_set, cl_set_hard_pipe.cl.test_score\n",
+    "\n",
+    "print \"\\nTESTING REGRESSORS\\n\"\n",
+    "for regressor in regressors:\n",
+    "    reg_pipe = ClassifierPipeline(positive_class=\"scores\")\n",
+    "    reg_pipe.setup(df_sample)\n",
+    "    reg_pipe.run(regressor)\n",
+    "    print \"regression:\", regressor, reg_pipe.cl.test_score"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 2",
+   "language": "python",
+   "name": "python2"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}


### PR DESCRIPTION
Added support for CSAT Regression, CSAT Satisfaction (>=3), and classifiers other than SVC, including aggregate voting

Test Output
![screen shot 2016-05-27 at 3 53 23 pm 2](https://cloud.githubusercontent.com/assets/14832482/15619588/300292de-2423-11e6-9565-b4036e358ab2.png)

Notes:
Code mostly adapted from svm_model.py
Might be able to delete svm_model.py, as the general model defaults to SVC
